### PR TITLE
add example for building a rpm for the shared nginx module on centos7

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,43 @@ make
 sudo make install
 ```
 
+## Building from source on Centos7 (includes libxjwt build)
+
+```
+sudo yum install git wget pcre-devel zlib-devel libcurl-devel scons jansson-devel openssl-devel -y
+sudo yum groupinstall "Development Tools" -y
+git clone https://github.com/ScaleFT/libxjwt.git
+git clone git@github.com:ScaleFT/nginx_auth_accessfabric.git
+cd libxjwt/
+scons build
+sudo scons install
+cd ..
+echo /usr/local/lib | sudo tee -a /etc/ld.so.conf.d/local.conf
+sudo ldconfig
+# Prerelease step.
+wget http://nginx.org/download/nginx-1.13.7.tar.gz
+tar xvzf nginx-1.13.7.tar.gz
+cd nginx-1.13.7
+./configure --add-dynamic-module=../nginx_auth_accessfabric --with-http_ssl_module
+make
+sudo make install
+```
+
+## Building an rpm for Centos7 using the patch for the nginx.spec file (dist/rpm/centos7/nginx.spec.patch)
+You may need to adjust versions here and in the patch.  This is provide mainly as a template to aid in building an rpm suitable for use with the factory nginx rpm.
+This assumes you have built or aquired and installed libxjwt and libxjwt-devel via rpm. (There's a spec file for building that rpm in it's repo.)
+```
+sudo yum install redhat-rpm-config rpm-build -y
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+echo '%_topdir %(echo $HOME)/rpmbuild' > ~/.rpmmacros
+yumdownloader --source nginx
+rpm -ivh ./nginx-1.12.2-1.el7.src.rpm
+cd ~/rpmbuild/SPECS
+patch < nginx.spec.patch
+rpmbuild -ba ~/rpmbuild/SPECS/nginx.spec
+sudo rpm -i ~/rpmbuild/RPMS/nginx-mod-http-auth-accessfabric-1.12.2-1.el7.centos.x86_64.rpm
+```
+
 # License
 
 `nginx_auth_accessfabric` is licensed under the Apache License Version 2.0. See the [LICENSE file](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,10 @@ make
 sudo make install
 ```
 
-## Building an rpm for CentOS 7 using the patch for the [nginx.spec file](./dist/rpm/centos7/nginx.spec.patch)
-You may need to adjust versions here and in the patch.  This is provide mainly as a template to aid in building a module rpm suitable for use with the factory nginx rpm.
-This assumes you have built or aquired and installed libxjwt and libxjwt-devel via rpm. There's a spec file for building that rpm in it's repo [here.](https://github.com/ScaleFT/libxjwt/blob/master/dist/rpm/libxjwt.spec)
-If you built the rpm for libjwxt, you can skip these steps and start with yumdownloader.
+## Building an rpm for CentOS 7 using the [patch](./dist/rpm/centos7/nginx.spec.patch) for the nginx.spec file.
+You may need to adjust versions in the instuctions and in the [patch](./dist/rpm/centos7/nginx.spec.patch).  This is provide mainly as a template to aid in building a module rpm suitable for use with the factory nginx rpm.
+This assumes you have built or aquired and installed libxjwt and libxjwt-devel via rpm. There is a spec file for building that rpm in it's repo [here](https://github.com/ScaleFT/libxjwt/blob/master/dist/rpm/libxjwt.spec).
+If you have already built the rpm for libjwxt on the same build host, you may skip these steps and start with yumdownloader.
 ```
 sudo yum install redhat-rpm-config rpm-build -y
 mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}

--- a/README.md
+++ b/README.md
@@ -63,20 +63,18 @@ make
 sudo make install
 ```
 
-## Building from source on Centos7 (includes libxjwt build)
+## Building from source on Centos7 (includes libxjwt rpm build and install) You may need to adjust versions.
 
 ```
-sudo yum install git wget pcre-devel zlib-devel libcurl-devel scons jansson-devel openssl-devel -y
+sudo yum install git wget pcre-devel zlib-devel libcurl-devel jansson-devel openssl-devel redhat-rpm-config rpm-build -y
 sudo yum groupinstall "Development Tools" -y
 git clone https://github.com/ScaleFT/libxjwt.git
-git clone git@github.com:ScaleFT/nginx_auth_accessfabric.git
-cd libxjwt/
-scons build
-sudo scons install
-cd ..
-echo /usr/local/lib | sudo tee -a /etc/ld.so.conf.d/local.conf
-sudo ldconfig
-# Prerelease step.
+git clone https://github.com/ScaleFT/nginx_auth_accessfabric.git 
+mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+echo '%_topdir %(echo $HOME)/rpmbuild' > ~/.rpmmacros
+rpmbuild --undefine=_disable_source_fetch -bb ./libxjwt/dist/rpm/libxjwt.spec
+sudo rpm -i ./rpmbuild/RPMS/libxjwt-devel-1.0.2-1.el7.centos.x86_64.rpm
+sudo rpm -i ./rpmbuild/RPMS/libxjwt-1.0.2-1.el7.centos.x86_64.rpm
 wget http://nginx.org/download/nginx-1.13.7.tar.gz
 tar xvzf nginx-1.13.7.tar.gz
 cd nginx-1.13.7
@@ -85,16 +83,22 @@ make
 sudo make install
 ```
 
-## Building an rpm for Centos7 using the patch for the nginx.spec file (dist/rpm/centos7/nginx.spec.patch)
-You may need to adjust versions here and in the patch.  This is provide mainly as a template to aid in building an rpm suitable for use with the factory nginx rpm.
-This assumes you have built or aquired and installed libxjwt and libxjwt-devel via rpm. (There's a spec file for building that rpm in it's repo.)
+## Building an rpm for CentOS 7 using the patch for the [nginx.spec file](./dist/rpm/centos7/nginx.spec.patch)
+You may need to adjust versions here and in the patch.  This is provide mainly as a template to aid in building a module rpm suitable for use with the factory nginx rpm.
+This assumes you have built or aquired and installed libxjwt and libxjwt-devel via rpm. There's a spec file for building that rpm in it's repo [here.](https://github.com/ScaleFT/libxjwt/blob/master/dist/rpm/libxjwt.spec)
+If you built the rpm for libjwxt, you can skip these steps and start with yumdownloader.
 ```
 sudo yum install redhat-rpm-config rpm-build -y
 mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 echo '%_topdir %(echo $HOME)/rpmbuild' > ~/.rpmmacros
+```
+```
 yumdownloader --source nginx
 rpm -ivh ./nginx-1.12.2-1.el7.src.rpm
 cd ~/rpmbuild/SPECS
+```
+Aquire the patch [file](./dist/rpm/centos7/nginx.spec.patch)
+```
 patch < nginx.spec.patch
 rpmbuild -ba ~/rpmbuild/SPECS/nginx.spec
 sudo rpm -i ~/rpmbuild/RPMS/nginx-mod-http-auth-accessfabric-1.12.2-1.el7.centos.x86_64.rpm

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ yumdownloader --source nginx
 rpm -ivh ./nginx-1.12.2-1.el7.src.rpm
 cd ~/rpmbuild/SPECS
 ```
-Aquire the patch [file](./dist/rpm/centos7/nginx.spec.patch)
+Aquire the patch [file](./dist/rpm/centos7/nginx.spec.patch), apply, build and install the rpm.
 ```
 patch < nginx.spec.patch
 rpmbuild -ba ~/rpmbuild/SPECS/nginx.spec

--- a/dist/rpm/centos7/nginx.spec.patch
+++ b/dist/rpm/centos7/nginx.spec.patch
@@ -1,0 +1,66 @@
+--- nginx.spec  2017-10-18 08:08:23.000000000 +0000
++++ nginx.spec.af       2017-12-26 16:02:21.949915944 +0000
+@@ -86,6 +86,7 @@
+ Requires:          nginx-mod-http-xslt-filter = %{epoch}:%{version}-%{release}
+ Requires:          nginx-mod-mail = %{epoch}:%{version}-%{release}
+ Requires:          nginx-mod-stream = %{epoch}:%{version}-%{release}
++Requires:          nginx-mod-http-auth-accessfabric = %{epoch}:%{version}-%{release}
+
+ %description all-modules
+ %{summary}.
+@@ -168,6 +169,14 @@
+ %description mod-stream
+ %{summary}.
+
++%package mod-http-auth-accessfabric
++Group:             System Environment/Daemons
++Summary:           ScaleFT Accessfabric Auth module 
++Requires:          nginx
++Requires:          libxjwt-devel
++
++%description mod-http-auth-accessfabric
++%{summary}.
+
+ %prep
+ %setup -q
+@@ -238,6 +247,7 @@
+ %endif
+     --with-debug \
+     --with-cc-opt="%{optflags} $(pcre-config --cflags)" \
++    --add-dynamic-module="/home/chris_rhodes/nginx_auth_accessfabric" \
+     --with-ld-opt="$RPM_LD_FLAGS -Wl,-E" # so the perl module finds its symbols
+
+ make %{?_smp_mflags}
+@@ -303,6 +313,8 @@
+     > %{buildroot}%{_datadir}/nginx/modules/mod-mail.conf
+ echo 'load_module "%{_libdir}/nginx/modules/ngx_stream_module.so";' \
+     > %{buildroot}%{_datadir}/nginx/modules/mod-stream.conf
++echo 'load_module "%{_libdir}/nginx/modules/ngx_http_auth_accessfabric_module.so";' \
++    > %{buildroot}%{_datadir}/nginx/modules/mod-http-auth-accessfabric.conf
+
+ %pre filesystem
+ getent group %{nginx_user} > /dev/null || groupadd -r %{nginx_user}
+@@ -344,6 +356,11 @@
+     /usr/bin/systemctl reload nginx.service >/dev/null 2>&1 || :
+ fi
+
++%post mod-http-auth-accessfabric
++if [ $1 -eq 1 ]; then
++    /usr/bin/systemctl reload nginx.service >/dev/null 2>&1 || :
++fi
++
+ %preun
+ %systemd_preun nginx.service
+
+@@ -428,6 +445,11 @@
+ %{_datadir}/nginx/modules/mod-stream.conf
+ %{_libdir}/nginx/modules/ngx_stream_module.so
+
++%files mod-http-auth-accessfabric
++%{_datadir}/nginx/modules/mod-http-auth-accessfabric.conf
++%{_libdir}/nginx/modules/ngx_http_auth_accessfabric_module.so
++
++
+
+ %changelog
+ * Wed Oct 18 2017 Luboš Uhliarik <luhliari@redhat.com> - 1:1.12.2-1


### PR DESCRIPTION
This adds a spec file patch and instructions for building an rpm for nginx on centos7.  This is mainly meant as an example/template since the nginx rpm on centos is a moving target and versions of things will change.