### PR TITLE
Fix bug in JWK Refreshing

### DIFF
--- a/ngx_http_auth_accessfabric_module.c
+++ b/ngx_http_auth_accessfabric_module.c
@@ -981,6 +981,7 @@ static ngx_int_t af_jwk__thread_main(af_jwk_refresher_t *jr) {
       }
     } else {
       if (rv == ETIMEDOUT) {
+        pthread_mutex_unlock(&jr->mtx);
         af_jwk__refresh(jr);
       }
     }


### PR DESCRIPTION
On condvar timeout, unlock, as the mutex is reacquired prior to returning from a timeout.  Broken during a refactoring.